### PR TITLE
chore: change generateUserHash to generateHMAC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ class BackendSDK {
   }
 
   // creates sha256 HMAC from the api secret key and username
-  generateUserHash(username: string): string {
+  generateHMAC(username: string): string {
     return crypto
       .createHmac("sha256", this.secretKey)
       .update(username)

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ function isValid(...args: string[]) {
   return true;
 }
 
-class BackendSDK {
+class TelegraphBackendSDK {
   baseUrl: string;
   secretKey: string;
 
@@ -245,4 +245,4 @@ class BackendSDK {
   }
 }
 
-export default BackendSDK;
+export default TelegraphBackendSDK;


### PR DESCRIPTION
`generateHMAC` is more consistent with our case study than `generateUserHash`.
